### PR TITLE
fix issues with puppet6

### DIFF
--- a/manifests/bind.pp
+++ b/manifests/bind.pp
@@ -60,7 +60,7 @@
 # @see puppet_classes::yp::ldap ::yp::ldap
 class yp::bind (
   String                                    $domain,
-  Optional[Array[IP::Address::NoSubnet, 1]] $servers        = undef,
+  Optional[Array[Stdlib::IP::Address::Nosubnet, 1]] $servers        = undef,
   Boolean                                   $manage_package = $::yp::params::bind_manage_package,
   Optional[String]                          $package_name   = $::yp::params::bind_package_name,
   String                                    $service_name   = $::yp::params::bind_service_name,

--- a/manifests/bind.pp
+++ b/manifests/bind.pp
@@ -59,11 +59,11 @@
 # @see puppet_classes::yp::serv ::yp::serv
 # @see puppet_classes::yp::ldap ::yp::ldap
 class yp::bind (
-  String                                    $domain,
+  String                                            $domain,
   Optional[Array[Stdlib::IP::Address::Nosubnet, 1]] $servers        = undef,
-  Boolean                                   $manage_package = $::yp::params::bind_manage_package,
-  Optional[String]                          $package_name   = $::yp::params::bind_package_name,
-  String                                    $service_name   = $::yp::params::bind_service_name,
+  Boolean                                           $manage_package = $::yp::params::bind_manage_package,
+  Optional[String]                                  $package_name   = $::yp::params::bind_package_name,
+  String                                            $service_name   = $::yp::params::bind_service_name,
 ) inherits ::yp::params {
 
   contain ::yp::bind::install

--- a/manifests/serv.pp
+++ b/manifests/serv.pp
@@ -81,23 +81,23 @@
 # @see puppet_classes::yp::bind ::yp::bind
 # @see puppet_classes::yp::ldap ::yp::ldap
 class yp::serv (
-  String                                    $domain,
-  Boolean                                   $has_yppasswdd          = $::yp::params::serv_has_yppasswdd,
-  Boolean                                   $has_ypxfrd             = $::yp::params::serv_has_ypxfrd,
-  Boolean                                   $manage_package         = $::yp::params::serv_manage_package,
-  Array[String, 1]                          $maps                   = $::yp::params::serv_maps,
-  Optional[String]                          $map_extension          = $::yp::params::serv_map_extension,
+  String                                            $domain,
+  Boolean                                           $has_yppasswdd          = $::yp::params::serv_has_yppasswdd,
+  Boolean                                           $has_ypxfrd             = $::yp::params::serv_has_ypxfrd,
+  Boolean                                           $manage_package         = $::yp::params::serv_manage_package,
+  Array[String, 1]                                  $maps                   = $::yp::params::serv_maps,
+  Optional[String]                                  $map_extension          = $::yp::params::serv_map_extension,
   Optional[Stdlib::IP::Address::Nosubnet]           $master                 = undef,
-  Boolean                                   $merge_group            = $::yp::params::serv_merge_group,
-  Boolean                                   $merge_passwd           = $::yp::params::serv_merge_passwd,
-  Integer[0]                                $minimum_gid            = $::yp::params::serv_minimum_gid,
-  Integer[0]                                $minimum_uid            = $::yp::params::serv_minimum_uid,
-  Optional[String]                          $package_name           = $::yp::params::serv_package_name,
-  Optional[String]                          $yppasswdd_service_name = $::yp::params::serv_yppasswdd_service_name,
-  String                                    $ypserv_service_name    = $::yp::params::serv_ypserv_service_name,
-  Optional[String]                          $ypxfrd_service_name    = $::yp::params::serv_ypxfrd_service_name,
+  Boolean                                           $merge_group            = $::yp::params::serv_merge_group,
+  Boolean                                           $merge_passwd           = $::yp::params::serv_merge_passwd,
+  Integer[0]                                        $minimum_gid            = $::yp::params::serv_minimum_gid,
+  Integer[0]                                        $minimum_uid            = $::yp::params::serv_minimum_uid,
+  Optional[String]                                  $package_name           = $::yp::params::serv_package_name,
+  Optional[String]                                  $yppasswdd_service_name = $::yp::params::serv_yppasswdd_service_name,
+  String                                            $ypserv_service_name    = $::yp::params::serv_ypserv_service_name,
+  Optional[String]                                  $ypxfrd_service_name    = $::yp::params::serv_ypxfrd_service_name,
   Optional[Array[Stdlib::IP::Address::Nosubnet, 1]] $slaves                 = undef,
-  Stdlib::Absolutepath                      $yp_dir                 = $::yp::params::yp_dir,
+  Stdlib::Absolutepath                              $yp_dir                 = $::yp::params::yp_dir,
 ) inherits ::yp::params {
 
   if defined(Class['::yp::ldap']) {

--- a/manifests/serv.pp
+++ b/manifests/serv.pp
@@ -87,7 +87,7 @@ class yp::serv (
   Boolean                                   $manage_package         = $::yp::params::serv_manage_package,
   Array[String, 1]                          $maps                   = $::yp::params::serv_maps,
   Optional[String]                          $map_extension          = $::yp::params::serv_map_extension,
-  Optional[IP::Address::NoSubnet]           $master                 = undef,
+  Optional[Stdlib::IP::Address::Nosubnet]           $master                 = undef,
   Boolean                                   $merge_group            = $::yp::params::serv_merge_group,
   Boolean                                   $merge_passwd           = $::yp::params::serv_merge_passwd,
   Integer[0]                                $minimum_gid            = $::yp::params::serv_minimum_gid,
@@ -96,7 +96,7 @@ class yp::serv (
   Optional[String]                          $yppasswdd_service_name = $::yp::params::serv_yppasswdd_service_name,
   String                                    $ypserv_service_name    = $::yp::params::serv_ypserv_service_name,
   Optional[String]                          $ypxfrd_service_name    = $::yp::params::serv_ypxfrd_service_name,
-  Optional[Array[IP::Address::NoSubnet, 1]] $slaves                 = undef,
+  Optional[Array[Stdlib::IP::Address::Nosubnet, 1]] $slaves                 = undef,
   Stdlib::Absolutepath                      $yp_dir                 = $::yp::params::yp_dir,
 ) inherits ::yp::params {
 

--- a/manifests/serv/map.pp
+++ b/manifests/serv/map.pp
@@ -1,10 +1,10 @@
 # @!visibility private
 define yp::serv::map (
-  String                          $domain,
-  Optional[String]                $extension,
+  String                                  $domain,
+  Optional[String]                        $extension,
   Optional[Stdlib::IP::Address::Nosubnet] $master,
-  Stdlib::Absolutepath            $yp_dir,
-  String                          $map       = $name,
+  Stdlib::Absolutepath                    $yp_dir,
+  String                                  $map       = $name,
 ) {
 
   if $master {

--- a/manifests/serv/map.pp
+++ b/manifests/serv/map.pp
@@ -2,7 +2,7 @@
 define yp::serv::map (
   String                          $domain,
   Optional[String]                $extension,
-  Optional[IP::Address::NoSubnet] $master,
+  Optional[Stdlib::IP::Address::Nosubnet] $master,
   Stdlib::Absolutepath            $yp_dir,
   String                          $map       = $name,
 ) {

--- a/manifests/serv/service.pp
+++ b/manifests/serv/service.pp
@@ -29,13 +29,14 @@ class yp::serv::service {
 
   if $::yp::serv::has_ypxfrd {
 
-    $ypxfrd_ensure = size($::yp::serv::slaves) ? {
-      0       => stopped,
-      default => running,
-    }
-    $ypxfrd_enable = size($::yp::serv::slaves) ? {
-      0       => false,
-      default => true,
+    #puppet6 does not allow size() arg to be undef, and array size is either greater than 1 thanks to parameter validation, or undef.
+    # empty array is not allowed.
+    if( $::yp::serv::slaves ) {
+      $ypxfrd_ensure = 'running'
+      $ypxfrd_enable = true
+    } else {
+      $ypxfrd_ensure = 'stopped'
+      $ypxfrd_enable = false
     }
 
     service { $::yp::serv::ypxfrd_service_name:

--- a/metadata.json
+++ b/metadata.json
@@ -49,7 +49,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=4.4.0 <6.0.0"
+      "version_requirement": ">=4.4.0 <7.0.0"
     }
   ],
   "tags": [
@@ -63,19 +63,15 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.13.0 <5.0.0"
+      "version_requirement": ">=5.0.0 <7.0.0"
     },
     {
       "name": "bodgit/bodgitlib",
       "version_requirement": ">=1.7.0 <3.0.0"
     },
     {
-      "name": "thrnio/ip",
-      "version_requirement": ">=1.0.0 <2.0.0"
-    },
-    {
       "name": "puppetlabs/concat",
-      "version_requirement": ">=2.1.0 <5.0.0"
+      "version_requirement": ">=2.1.0 <6.2.0"
     }
   ]
 }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -20,7 +20,6 @@ RSpec.configure do |c|
       on host, puppet('module', 'install', 'bodgit-portmap'),                   { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'puppetlabs-stdlib'),                { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'bodgit-bodgitlib'),                 { :acceptable_exit_codes => [0,1] }
-      on host, puppet('module', 'install', 'thrnio-ip'),                        { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'trlinkin-nsswitch'),                { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'herculesteam-augeasproviders_pam'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'bodgit-openldap'),                  { :acceptable_exit_codes => [0,1] }


### PR DESCRIPTION
- wrong stdlib puppet types for IP::Address::Nosubnet
- size() function now rejects undef which is the default when no slave is configured